### PR TITLE
32 rely on end offset instead of eof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ cython_debug/
 /.ruff_cache
 /poetry.lock
 /venv
+*.csv
+coverrage.xml

--- a/beavers/kafka.py
+++ b/beavers/kafka.py
@@ -611,7 +611,7 @@ def _resolve_topic_offsets(
             source_topic.absolute_time, consumer, watermarks, timeout
         )
     elif source_topic.offset_policy == OffsetPolicy.COMMITTED:
-        committed = consumer.committed(watermarks.keys())
+        committed = consumer.committed(list(watermarks.keys()), timeout=timeout)
         return {
             confluent_kafka.TopicPartition(topic=tp.topic, partition=tp.partition): (
                 tp.offset,

--- a/beavers/kafka.py
+++ b/beavers/kafka.py
@@ -16,8 +16,6 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-KAFKA_EOF_CODE = -191
-
 
 class KafkaMessageDeserializer(Protocol[T]):
     """Interface for converting incoming kafka messages to custom data."""
@@ -224,10 +222,12 @@ class _ProducerManager:
 @dataclasses.dataclass
 class _PartitionInfo:
     current_offset: int
+    live_offset: int
     timestamp_ns: int = UTC_EPOCH.value
     paused: bool = False
-    primed: bool = False
-    eof: bool = False
+
+    def is_live(self) -> bool:
+        return self.current_offset >= self.live_offset
 
 
 @dataclasses.dataclass
@@ -245,7 +245,7 @@ class _ConsumerManager:
     def __init__(
         self,
         cutoff: pd.Timestamp,
-        partitions: list[confluent_kafka.TopicPartition],
+        partitions: dict[confluent_kafka.TopicPartition : tuple[int, int]],
         consumer: confluent_kafka.Consumer,
         batch_size: int,
         max_held_messages: int,
@@ -253,7 +253,8 @@ class _ConsumerManager:
         self._cutoff_ns: int = cutoff.value
         self._consumer: confluent_kafka.Consumer = consumer
         self._partition_info: dict[confluent_kafka.TopicPartition, _PartitionInfo] = {
-            partition: _PartitionInfo(partition.offset) for partition in partitions
+            tp: _PartitionInfo(current_offset=start, live_offset=end)
+            for tp, (start, end) in partitions.items()
         }
         self._held_messages: list[confluent_kafka.Message] = []
         self._batch_size: int = batch_size
@@ -269,12 +270,17 @@ class _ConsumerManager:
         batch_size: int,
         timeout: Optional[float],
     ) -> "_ConsumerManager":
-        if not consumer_config.get("enable.partition.eof"):
-            raise ValueError("'enable.partition.eof' should be set to true")
         consumer = confluent_kafka.Consumer(consumer_config)
         cutoff = pd.Timestamp.utcnow()
         offsets = _resolve_topics_offsets(consumer, source_topics, cutoff, timeout)
-        consumer.assign(offsets)
+        consumer.assign(
+            [
+                confluent_kafka.TopicPartition(
+                    topic=tp.topic, partition=tp.partition, offset=start
+                )
+                for tp, (start, _) in offsets.items()
+            ]
+        )
         return _ConsumerManager(cutoff, offsets, consumer, batch_size, batch_size * 5)
 
     def poll(self, timeout: float) -> list[confluent_kafka.Message]:
@@ -366,20 +372,11 @@ class _ConsumerManager:
             )
             partition_info: _PartitionInfo = self._partition_info[topic_partition]
             timestamp_type, timestamp = message.timestamp()
-            if timestamp_type == confluent_kafka.TIMESTAMP_NOT_AVAILABLE:
-                if (
-                    message.error() is not None
-                    and message.error().code() == KAFKA_EOF_CODE
-                ):
-                    partition_info.eof = True
-            else:
+            if timestamp_type != confluent_kafka.TIMESTAMP_NOT_AVAILABLE:
                 partition_info.timestamp_ns = timestamp * 1_000_000
-                partition_info.eof = False
             partition_info.current_offset = message.offset()
-            if partition_info.timestamp_ns >= self._cutoff_ns:
-                partition_info.primed = True
         self._low_water_mark_ns = min(
-            (v.timestamp_ns for v in self._partition_info.values() if not v.eof),
+            (v.timestamp_ns for v in self._partition_info.values() if not v.is_live()),
             default=pd.Timestamp.utcnow().value,
         )
 
@@ -567,10 +564,10 @@ def _resolve_topics_offsets(
     source_topics: list[SourceTopic],
     now: pd.Timestamp,
     timeout: Optional[float] = None,
-) -> list[confluent_kafka.TopicPartition]:
-    assignments: list[confluent_kafka.TopicPartition] = []
+) -> dict[confluent_kafka.TopicPartition, tuple[int, int]]:
+    assignments = {}
     for source_topic in source_topics:
-        assignments.extend(_resolve_topic_offsets(consumer, source_topic, now, timeout))
+        assignments.update(_resolve_topic_offsets(consumer, source_topic, now, timeout))
     return assignments
 
 
@@ -579,7 +576,7 @@ def _resolve_topic_offsets(
     source_topic: SourceTopic,
     now: pd.Timestamp,
     timeout: Optional[float] = None,
-) -> list[confluent_kafka.TopicPartition]:
+) -> dict[confluent_kafka.TopicPartition, tuple[int, int]]:
     cluster_metadata: confluent_kafka.admin.ClusterMetadata = consumer.list_topics(
         source_topic.name, timeout
     )
@@ -588,71 +585,40 @@ def _resolve_topic_offsets(
     ]
     if len(topic_meta_data.partitions) == 0:
         raise ValueError(f"Topic {source_topic.name} does not exist")
+    watermarks = {
+        confluent_kafka.TopicPartition(
+            source_topic.name, p.id
+        ): consumer.get_watermark_offsets(
+            confluent_kafka.TopicPartition(source_topic.name, p.id)
+        )
+        for p in topic_meta_data.partitions.values()
+    }
 
     if source_topic.offset_policy == OffsetPolicy.LATEST:
-        return [
-            confluent_kafka.TopicPartition(
-                topic=source_topic.name,
-                partition=p.id,
-                offset=confluent_kafka.OFFSET_END,
-            )
-            for p in topic_meta_data.partitions.values()
-        ]
+        return {tp: (end, end - 1) for tp, (start, end) in watermarks.items()}
     elif source_topic.offset_policy == OffsetPolicy.EARLIEST:
-        return [
-            confluent_kafka.TopicPartition(
-                topic=source_topic.name,
-                partition=p.id,
-                offset=confluent_kafka.OFFSET_BEGINNING,
-            )
-            for p in topic_meta_data.partitions.values()
-        ]
+        return {tp: (start, end - 1) for tp, (start, end) in watermarks.items()}
     elif source_topic.offset_policy == OffsetPolicy.RELATIVE_TIME:
         offset_timestamp = now - source_topic.relative_time
-        offset_ms = offset_timestamp.value // 1_000_000
-        return consumer.offsets_for_times(
-            [
-                confluent_kafka.TopicPartition(
-                    topic=source_topic.name, partition=p.id, offset=offset_ms
-                )
-                for p in topic_meta_data.partitions.values()
-            ],
-            timeout,
-        )
+        return _resolve_offset_for_time(offset_timestamp, consumer, watermarks, timeout)
     elif source_topic.offset_policy == OffsetPolicy.START_OF_DAY:
         offset_timestamp = _get_previous_start_of_day(
             now, source_topic.start_of_day_time, source_topic.start_of_day_timezone
         )
-        offset_ms = offset_timestamp.value // 1_000_000
-        return consumer.offsets_for_times(
-            [
-                confluent_kafka.TopicPartition(
-                    topic=source_topic.name, partition=p.id, offset=offset_ms
-                )
-                for p in topic_meta_data.partitions.values()
-            ],
-            timeout,
-        )
+        return _resolve_offset_for_time(offset_timestamp, consumer, watermarks, timeout)
     elif source_topic.offset_policy == OffsetPolicy.ABSOLUTE_TIME:
-        offset_ms = source_topic.absolute_time.value // 1_000_000
-        return consumer.offsets_for_times(
-            [
-                confluent_kafka.TopicPartition(
-                    topic=source_topic.name, partition=p.id, offset=offset_ms
-                )
-                for p in topic_meta_data.partitions.values()
-            ],
-            timeout,
+        return _resolve_offset_for_time(
+            source_topic.absolute_time, consumer, watermarks, timeout
         )
     elif source_topic.offset_policy == OffsetPolicy.COMMITTED:
-        return [
-            confluent_kafka.TopicPartition(
-                topic=source_topic.name,
-                partition=p.id,
-                offset=confluent_kafka.OFFSET_STORED,
+        committed = consumer.committed(watermarks.keys())
+        return {
+            confluent_kafka.TopicPartition(topic=tp.topic, partition=tp.partition): (
+                tp.offset,
+                watermarks[tp][1] - 1,
             )
-            for p in topic_meta_data.partitions.values()
-        ]
+            for tp in committed
+        }
     else:
         raise ValueError(
             f"{OffsetPolicy.__name__} {source_topic.offset_policy}"
@@ -694,3 +660,28 @@ def _get_message_ns(message: confluent_kafka.Message) -> int:
         return UTC_MAX.value
     else:
         return timestamp * 1_000_000
+
+
+def _resolve_offset_for_time(
+    offset_timestamp: pd.Timestamp,
+    consumer: confluent_kafka.Consumer,
+    watermarks: dict[confluent_kafka.TopicPartition, tuple[int, int]],
+    timeout: float,
+) -> dict[confluent_kafka.TopicPartition, tuple[int, int]]:
+    offset_ms = offset_timestamp.value // 1_000_000
+    offset_for_time = consumer.offsets_for_times(
+        [
+            confluent_kafka.TopicPartition(
+                topic=tp.topic, partition=tp.partition, offset=offset_ms
+            )
+            for tp in watermarks.keys()
+        ],
+        timeout,
+    )
+    return {
+        confluent_kafka.TopicPartition(topic=tp.topic, partition=tp.partition): (
+            tp.offset,
+            watermarks[tp][1] - 1,
+        )
+        for tp in offset_for_time
+    }

--- a/beavers/kafka.py
+++ b/beavers/kafka.py
@@ -239,6 +239,7 @@ class ConsumerMetrics:
     paused_partitions: int = 0
     released_message_count: int = 0
     held_message_count: int = 0
+    error_message_count: int = 0
 
 
 class _ConsumerManager:
@@ -291,6 +292,9 @@ class _ConsumerManager:
         )
         self._metrics.consumed_message_count += len(new_messages)
         self._metrics.consumed_message_size += sum(len(m.value()) for m in new_messages)
+        for message in new_messages:
+            if message.error():
+                self._metrics.error_message_count += 1
 
         self._held_messages.extend(new_messages)
         self._held_messages.sort(key=_get_message_ns)

--- a/examples/kafka_concepts.py
+++ b/examples/kafka_concepts.py
@@ -43,7 +43,7 @@ def deserialize_messages(messages: list[confluent_kafka.Message]) -> list[str]:
 from beavers.kafka import SourceTopic, KafkaDriver
 
 source_topic = SourceTopic.from_start_of_day(
-    "words2", deserialize_messages, pd.to_timedelta("15min"), "UTC"
+    "words", deserialize_messages, pd.to_timedelta("15min"), "UTC"
 )
 # --8<-- [end:kafka_source]
 
@@ -82,10 +82,8 @@ while True:
 # --8<-- [end:kafka_driver]
 
 
-# Note: you can test it with
+# Note: you can test it with the following commands
+# kafka-topics --create --topic words --bootstrap-server=localhost:9092
 # kafka-console-producer --topic words --bootstrap-server=localhost:9092
-# And:
-# kafka-console-consumer \
-#   --topic=counts \
-#   --bootstrap-server=localhost:9092 \
+# kafka-console-consumer --topic=counts --bootstrap-server=localhost:9092 \
 #   --property print.key=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pip-tools = "^6.12.1"
 pre-commit = ">=2.20.0"
 pylint = ">=2.15.0"
 pytest = ">=7.2.0"
+click = ">=8.1.7"
 mkdocs-material = ">=9.0.3"
 mkdocstrings = { version = ">=0.21.2", extras = ['python'] }
 mock = "*"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,22 @@
+# Scripts
+
+## `kafka_test_bench`
+
+Tests a simple application with kafka, making sure it replays in order.
+The "timestamp" of the output messages should be in order across topics when replaying.
+
+
+Helpful commands:
+
+```shell
+kafka-topics --create --topic left --bootstrap-server=localhost:9092
+kafka-topics --create --topic right --bootstrap-server=localhost:9092
+kafka-topics --create --topic both --bootstrap-server=localhost:9092
+kafka-console-producer --topic left --bootstrap-server=localhost:9092
+kafka-console-producer --topic right --bootstrap-server=localhost:9092
+kafka-console-consumer \
+    --topic=both \
+    --bootstrap-server=localhost:9092 \
+    --property print.key=true
+python -m scripts.kafka_test_bench --batch-size=2
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ The "timestamp" of the output messages should be in order across topics when rep
 Helpful commands:
 
 ```shell
+docker run -p 9092:9092 -d bashj79/kafka-kraft
 kafka-topics --create --topic left --bootstrap-server=localhost:9092
 kafka-topics --create --topic right --bootstrap-server=localhost:9092
 kafka-topics --create --topic both --bootstrap-server=localhost:9092

--- a/scripts/kafka_test_bench.py
+++ b/scripts/kafka_test_bench.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import logging
 from operator import itemgetter
 from typing import Any, Sequence
 
@@ -72,6 +73,11 @@ def kafka_test_bench(
     producer_config: dict,
     batch_size: int,
 ):
+    logging.basicConfig(
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        level=logging.DEBUG,
+    )
+
     dag = create_test_dag()
 
     driver = KafkaDriver.create(

--- a/scripts/kafka_test_bench.py
+++ b/scripts/kafka_test_bench.py
@@ -1,0 +1,95 @@
+import functools
+import json
+from operator import itemgetter
+from typing import Any, Sequence
+
+import click
+import confluent_kafka
+import pandas as pd
+
+from beavers import Dag
+from beavers.kafka import KafkaDriver, KafkaProducerMessage, SourceTopic
+
+
+def create_test_dag() -> "Dag":
+    dag = Dag()
+    left_stream = dag.source_stream(name="left")
+    right_stream = dag.source_stream(name="right")
+    both_stream = dag.stream(
+        lambda left, right: sorted(left + right, key=itemgetter("timestamp"))
+    ).map(left_stream, right_stream)
+    dag.sink("both", both_stream)
+    return dag
+
+
+def kafka_messages_to_json(
+    messages: Sequence[confluent_kafka.Message],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "topic": message.topic(),
+            "partition": message.partition(),
+            "offset": message.offset(),
+            "timestamp": str(
+                pd.to_datetime(message.timestamp()[1], unit="ms", utc=True)
+            ),
+            "key": message.key().encode("utf-8") if message.key() else None,
+            "value": message.value().decode("utf-8"),
+        }
+        for message in messages
+    ]
+
+
+def kafka_message_serializer(
+    payloads: list[dict[str, Any]], topic: str
+) -> list[KafkaProducerMessage]:
+    return [
+        KafkaProducerMessage(topic, key=None, value=json.dumps(payload))
+        for payload in payloads
+    ]
+
+
+@click.command()
+@click.option("--left-topic", type=click.STRING, default="left")
+@click.option("--right-topic", type=click.STRING, default="right")
+@click.option("--both-topic", type=click.STRING, default="both")
+@click.option(
+    "--consumer-config",
+    type=json.loads,
+    default='{"bootstrap.servers": "localhost:9092", "group.id": "beavers"}',
+)
+@click.option(
+    "--producer-config",
+    type=json.loads,
+    default='{"bootstrap.servers": "localhost:9092"}',
+)
+@click.option("--batch-size", type=click.INT, default="2")
+def kafka_test_bench(
+    left_topic: str,
+    right_topic: str,
+    both_topic: str,
+    consumer_config: dict,
+    producer_config: dict,
+    batch_size: int,
+):
+    dag = create_test_dag()
+
+    driver = KafkaDriver.create(
+        dag=dag,
+        producer_config=producer_config,
+        consumer_config=consumer_config,
+        source_topics={
+            "left": SourceTopic.from_earliest(left_topic, kafka_messages_to_json),
+            "right": SourceTopic.from_earliest(right_topic, kafka_messages_to_json),
+        },
+        sink_topics={
+            "both": functools.partial(kafka_message_serializer, topic=both_topic)
+        },
+        batch_size=batch_size,
+    )
+    while True:
+        driver.run_cycle()
+
+
+if __name__ == "__main__":
+    kafka_test_bench()


### PR DESCRIPTION
Historically we've been using EOF error messages to know when we're done replaying from kafka.

This approach has got draw backs:
- We need to explicitly turn it on in the config
- It makes error handling more complicated since we need a special handling logic for EOF marker
- The EOF marker doesn't tell you when you are done replaying past data for topic that emit during replay.

Instead of relying on this we will read the high watermark of each topic/partition when we start. As soon as we read a message higher or equal to  `high_watermark - 1` we know that this topic is live.